### PR TITLE
Do not force the user to press a key when -q is specified in the command line

### DIFF
--- a/src/melkor.c
+++ b/src/melkor.c
@@ -290,9 +290,11 @@ int main(int argc, char **argv)
 	printf("[+] The Likelihood of execution of each rule is: ");
 	printf("Aprox. %d %% (rand() %% %d < %d)\n\n", likelihood, like_a, like_b);
 
-	printf("[+] Press any key to start the fuzzing process...\n");
-
-	getchar();
+	if ( !quiet )
+	{
+		printf("[+] Press any key to start the fuzzing process...\n");
+		getchar();
+	}
 
 	chdir(dirname);
 


### PR DESCRIPTION
When in quiet mode don't force a user to press a key. It allows using this tool with other automations easily.
