### PR TITLE
Fix build on Ubuntu 20,22 and ARM64

### DIFF
--- a/src/fuzz_dyn.c
+++ b/src/fuzz_dyn.c
@@ -188,7 +188,7 @@ int dyn8(void)
 
 #if defined(__i386__)
 	Elf_Word d_val;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Xword d_val;
 #endif
 
@@ -268,7 +268,7 @@ int dyn11(void)
 
 #if defined(__i386__)
 	orcDYN->d_un.d_val = DT_RELA;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcDYN->d_un.d_val = DT_REL;
 #endif
 
@@ -316,7 +316,7 @@ int dyn13(void)
 
 #if defined(__i386__)
 	Elf_Sword d_tag;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Sxword d_tag;
 #endif
 
@@ -327,7 +327,7 @@ int dyn13(void)
 	} else
 #if defined(__i386__)
 		d_tag = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		d_tag = getElf_Xword();
 #endif
 
@@ -351,7 +351,7 @@ int dyn14(void)
 
 #if defined(__i386__)
 	Elf_Sword d_tag;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Sxword d_tag;
 #endif
 
@@ -365,7 +365,7 @@ int dyn14(void)
 	} else
 #if defined(__i386__)
 		d_tag = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		d_tag = getElf_Xword();
 #endif
 
@@ -386,7 +386,7 @@ int dyn15(void)
 
 #if defined(__i386__)
 	Elf_Sword d_tag;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Sxword d_tag;
 #endif
 
@@ -397,7 +397,7 @@ int dyn15(void)
 	} else
 #if defined(__i386__)
 		d_tag = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		d_tag = getElf_Xword();
 #endif
 
@@ -461,7 +461,7 @@ int dyn17(void)
 
 #if defined(__i386__)
 	Elf_Word d_val;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Xword d_val;
 #endif
 
@@ -474,7 +474,7 @@ int dyn17(void)
 
 #if defined(__i386__)
 		d_val += 8; // A ptr in 64-bit is 8 bytes. Add 8 to 32-bit ELF
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		d_val += 4; // Vice versa
 #endif
 	}
@@ -493,7 +493,7 @@ int dyn18(void)
 
 	// d_tag is a Sword (Signed Word)
 	if(rand() % 2){ // 50% chance to set d_tag to a negative number > 0x7fffffff
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 		if(rand() % 2)
 			orcDYN->d_tag = 0x8000000000000000 + (rand() % 0x7fffffff);
 		else

--- a/src/fuzz_pht.c
+++ b/src/fuzz_pht.c
@@ -204,7 +204,7 @@ int pht4(void)
 
 #if defined(__i386__)
 	Elf_Word  p_memsz;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Xword p_memsz;
 #endif
 	int r = rand();
@@ -213,7 +213,7 @@ int pht4(void)
 		orcPHT->p_filesz = 0;
 #if defined(__i386__)
 		while((p_memsz = getElf_Word()))
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		while((p_memsz = getElf_Xword()))
 #endif
 			if(p_memsz % PAGESIZE == 0){
@@ -223,7 +223,7 @@ int pht4(void)
 	} else if(r % 3 == 1){
 #if defined(__i386__)
 		orcPHT->p_filesz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		orcPHT->p_filesz = getElf_Xword();
 #endif
 		orcPHT->p_memsz = 0;
@@ -251,7 +251,7 @@ int pht5(void)
 	} else
 #if defined(__i386__)
 		orcPHT->p_align = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		orcPHT->p_align = getElf_Xword();
 #endif
 
@@ -305,14 +305,14 @@ int pht7(void)
 
 #if defined(__i386__)
 	Elf_Word p_filesz;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Xword p_filesz;
 #endif
 
 	if(rand() % 3 < 2){
 #if defined(__i386__)
 		while((p_filesz = getElf_Word()))
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		while((p_filesz = getElf_Xword()))
 #endif
 			if(p_filesz >= orcPHT->p_memsz){
@@ -322,7 +322,7 @@ int pht7(void)
 	} else
 #if defined(__i386__)
 		orcPHT->p_filesz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		orcPHT->p_filesz = getElf_Xword();
 #endif
 
@@ -341,7 +341,7 @@ int pht8(void)
 
 #if defined(__i386__)
 	Elf_Word p_filesz;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Xword p_filesz;
 #endif
 
@@ -537,18 +537,18 @@ int pht16(void)
 	orcPHT->p_vaddr  = getElf_Addr();
 #if defined(__i386__)
 	orcPHT->p_filesz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_filesz = getElf_Xword();
 #endif
 #if defined(__i386__)
 	orcPHT->p_memsz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_memsz = getElf_Xword();
 #endif
 	orcPHT->p_flags = getElf_Word();
 #if defined(__i386__)
 	orcPHT->p_align = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_align = getElf_Xword();
 #endif
 
@@ -572,18 +572,18 @@ int pht17(void)
 	orcPHT->p_vaddr  = getElf_Addr();
 #if defined(__i386__)
 	orcPHT->p_filesz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_filesz = getElf_Xword();
 #endif
 #if defined(__i386__)
 	orcPHT->p_memsz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_memsz = getElf_Xword();
 #endif
 	orcPHT->p_flags = getElf_Word();
 #if defined(__i386__)
 	orcPHT->p_align = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_align = getElf_Xword();
 #endif
 
@@ -607,18 +607,18 @@ int pht18(void)
 	orcPHT->p_vaddr  = getElf_Addr();
 #if defined(__i386__)
 	orcPHT->p_filesz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_filesz = getElf_Xword();
 #endif
 #if defined(__i386__)
 	orcPHT->p_memsz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_memsz = getElf_Xword();
 #endif
 	orcPHT->p_flags = getElf_Word();
 #if defined(__i386__)
 	orcPHT->p_align = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	orcPHT->p_align = getElf_Xword();
 #endif
 
@@ -768,18 +768,18 @@ int pht22(void)
 		tmpPHT->p_vaddr  = getElf_Addr();
 #if defined(__i386__)
 		tmpPHT->p_filesz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		tmpPHT->p_filesz = getElf_Xword();
 #endif
 #if defined(__i386__)
 		tmpPHT->p_memsz = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		tmpPHT->p_memsz = getElf_Xword();
 #endif
 		tmpPHT->p_flags = getElf_Word();
 #if defined(__i386__)
 		tmpPHT->p_align = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		tmpPHT->p_align = getElf_Xword();
 #endif
 

--- a/src/fuzz_rel.c
+++ b/src/fuzz_rel.c
@@ -82,13 +82,13 @@ int rel2(void)
 		if(orcSHT->sh_type == SHT_REL)
 #if defined(__i386__)
 			orcREL->r_info = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 			orcREL->r_info = getElf_Xword();
 #endif
 		else
 #if defined(__i386__)
 			orcRELA->r_info = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 			orcRELA->r_info = getElf_Xword();
 #endif
 	}
@@ -108,7 +108,7 @@ int rel3(void)
 
 	// r_addend is a Sword (Signed Word)
 	if(rand() % 2){ // 75% chance to set r_addend to a negative number > 0x7fffffff
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 		if(rand() % 2)
 			orcRELA->r_addend = 0x8000000000000000 + (rand() % 0x7fffffff);
 		else

--- a/src/fuzz_sht.c
+++ b/src/fuzz_sht.c
@@ -751,7 +751,7 @@ int sht20(void)
 
 #if defined(__i386__)
 	Elf_Word s;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 	Elf_Xword s;
 #endif
 
@@ -760,7 +760,7 @@ int sht20(void)
 	if(r % 3 == 0) // If running in 64 bits, set a size modulo the 32-bits struct's size and viceversa
 #if defined(__i386__)
 		s = sizeof(Elf64_Nhdr);
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		s = sizeof(Elf32_Nhdr);
 #endif
 	else if(r % 3 == 1){
@@ -1483,7 +1483,7 @@ void fuzzSize()
 		if(rand() % 2)
 #if defined(__i386__)
 			orcSHT->sh_size = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 			orcSHT->sh_size = getElf_Xword();
 #endif
 		else
@@ -1498,7 +1498,7 @@ void fuzzEntSize()
 		if(rand() % 2)
 #if defined(__i386__)
 			orcSHT->sh_entsize = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 			orcSHT->sh_entsize = getElf_Xword();
 		else
 			orcSHT->sh_entsize = getElf_Half();
@@ -1542,7 +1542,7 @@ void fuzzFlags()
 	} else {
 #if defined(__i386__)
 		orcSHT->sh_flags = getElf_Word();
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		orcSHT->sh_flags = getElf_Xword();
 #endif
 	}
@@ -1553,7 +1553,7 @@ void fuzzAddrAlign()
 	if(rand() % 2){ // 50% chance
 #if defined(__i386__)
 		while((orcSHT->sh_addralign = getElf_Word()))
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 		while((orcSHT->sh_addralign = getElf_Xword()))
 #endif
 			// Bitwise: x & (x - 1) != 0 if x is NOT a power of 2

--- a/src/melkor.c
+++ b/src/melkor.c
@@ -54,6 +54,7 @@ Elf_Off		elfshstrtab_offset = 0, orcshstrtab_offset = 0, linkstrtab_offset = 0;
 Elf_Shdr	*orcOrigSHT;
 Elf_Phdr	*orcOrigPHT;
 Elf_Dyn		*elfOrigDYN;
+int PAGESIZE;
 
 extern int errno;
 

--- a/src/melkor.h
+++ b/src/melkor.h
@@ -39,7 +39,7 @@
 */
 typedef int (*func_ptr)(void);
 
-int PAGESIZE; // Set at runtime with getpagesize() in melkor.c
+extern int PAGESIZE; // Set at runtime with getpagesize() in melkor.c
 
 #ifndef PT_GNU_STACK
 #define PT_GNU_STACK 0x6474e551 // Indicates executable stack
@@ -112,7 +112,7 @@ int PAGESIZE; // Set at runtime with getpagesize() in melkor.c
 
 #define HEX "%.8x"
 
-#elif defined(__x86_64__)       /**** x86_64 ****/
+#elif defined(__x86_64__) || defined(__aarch64__)      /**** x86_64 ****/
 // Data Types
 #define Elf_Half Elf64_Half
 #define Elf_Word Elf64_Word


### PR DESCRIPTION
 - One tweak to fix a multiple define in linker stage (variable defined in header file).
 - To get it to build on ARM64, add `defined(__aarch64__)` anywhere there's a `defined(__x86_64__)` .  They are both 64-bit, and I don't think there's any CPU/instruction-set specifics.
