### PR TITLE
Fixed compilation error with gcc 13.3.0

### DIFF
--- a/src/melkor.c
+++ b/src/melkor.c
@@ -31,6 +31,7 @@
 /* GLOBAL VARS */
 FILE		*logfp;
 struct stat	elfstatinfo;
+int 		PAGESIZE;
 unsigned int	mode = 0;   // Metadata to fuzz (parameters)
 unsigned int	orcn = 0;   // OrcN inside the for() loop. fuzz_* modules will use it through different loops
 unsigned int	n = 5000;   // Default for option -n

--- a/src/melkor.h
+++ b/src/melkor.h
@@ -39,7 +39,7 @@
 */
 typedef int (*func_ptr)(void);
 
-int PAGESIZE; // Set at runtime with getpagesize() in melkor.c
+extern int PAGESIZE; // Set at runtime with getpagesize() in melkor.c
 
 #ifndef PT_GNU_STACK
 #define PT_GNU_STACK 0x6474e551 // Indicates executable stack


### PR DESCRIPTION
Trying to compile Melkor using `gcc version 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04)` on Ubuntu 24.04 x86_64 (WSL2) resulted in multiple definitions of `PAGESIZE` in `melkor.h`.
The fix is defining global variable PAGESIZE in `melkor.c` and making it `extern` in `melkor.h`.